### PR TITLE
Change Taskbar to a Singleton Object

### DIFF
--- a/app/src/main/java/com/example/barqrxmls/LeaderBoard.java
+++ b/app/src/main/java/com/example/barqrxmls/LeaderBoard.java
@@ -59,7 +59,8 @@ public class LeaderBoard extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.leaderboard_screen);
 
-        Taskbar taskbar = new Taskbar(LeaderBoard.this);
+//        Taskbar taskbar = new Taskbar(LeaderBoard.this);
+        Taskbar taskbar = Taskbar.getInstance(LeaderBoard.this);
         // setting screen changes from taskbar
         // <Praveenkumar, Gary> (<Nov. 9, 2016>) <How to switch between screens?> (<4>) [<source code>] https://stackoverflow.com/questions/7991393/how-to-switch-between-screens
 

--- a/app/src/main/java/com/example/barqrxmls/MainActivity.java
+++ b/app/src/main/java/com/example/barqrxmls/MainActivity.java
@@ -198,7 +198,9 @@ public class MainActivity extends AppCompatActivity {
 //        dataBase = FirebaseFirestore.getInstance();
 //        mAuth = FirebaseAuth.getInstance();
 
-        Taskbar taskbar = new Taskbar(MainActivity.this);
+//        Taskbar taskbar = new Taskbar(MainActivity.this);
+        Taskbar taskbar = Taskbar.getInstance(MainActivity.this);
+
         // setting screen changes from taskbar
         // <Praveenkumar, Gary> (<Nov. 9, 2016>) <How to switch between screens?> (<4>) [<source code>] https://stackoverflow.com/questions/7991393/how-to-switch-between-screens
 

--- a/app/src/main/java/com/example/barqrxmls/Taskbar.java
+++ b/app/src/main/java/com/example/barqrxmls/Taskbar.java
@@ -17,20 +17,36 @@ import java.util.HashMap;
  */
 public class Taskbar {
     HashMap<String, OnClickListener> switchActivityMap;
-    Context callerContext;
+    //Context callerContext;
+    private static Taskbar instance = null;
+
+    public static Taskbar getInstance(Context context) {
+        if (instance == null) {
+            instance = new Taskbar(context);
+        }
+        return instance;
+    }
+
+
+    public void setupDefaultTaskbar(Context context) {
+        makeTaskbar(context,
+                new ArrayList<>(Arrays.asList(MainActivity.class, LeaderBoard.class, Map.class, NewCode.class, Account.class)),
+                new ArrayList<>(Arrays.asList("MainActivity", "LeaderBoard", "Map", "NewCode", "Account"))
+        );
+    }
 
     /**
      * Construct a default taskbar
      *
      * This constructor creates a default taskbar for the current layout of the app.
      * Internally, it calls the second constructor with a default list of arguments.
-     * @param context The caller's context, required for view switching to work.
      */
-    public Taskbar(Context context) {
-        this(   context,
-                new ArrayList<>(Arrays.asList(MainActivity.class, LeaderBoard.class, Map.class, NewCode.class, Account.class)),
-                new ArrayList<>(Arrays.asList("MainActivity", "LeaderBoard", "Map", "NewCode", "Account"))
-        );
+    private Taskbar(Context context) {
+        setupDefaultTaskbar(context);
+//        this(instance.callerContext,
+//                new ArrayList<>(Arrays.asList(MainActivity.class, LeaderBoard.class, Map.class, NewCode.class, Account.class)),
+//                new ArrayList<>(Arrays.asList("MainActivity", "LeaderBoard", "Map", "NewCode", "Account"))
+//        );
     }
 
     // Class generic creation style from StackOverflow (<? extends ...> and <T extends ...>)
@@ -46,12 +62,11 @@ public class Taskbar {
      * @param classList List of classes, such as MainActivity.class or HomeActivity.class
      * @param activityNames List of strings corresponding 1:1 to class list.
      */
-    public Taskbar(Context context, ArrayList<Class<? extends AppCompatActivity>> classList, ArrayList<String> activityNames) {
-        this.callerContext = context;
+    private void makeTaskbar(Context context, ArrayList<Class<? extends AppCompatActivity>> classList, ArrayList<String> activityNames) {
         assert(classList.size() == activityNames.size());
         HashMap<String, OnClickListener> listenerHashMap = new HashMap<>();
         for (int i = 0; i < classList.size(); i++) {
-            listenerHashMap.put(activityNames.get(i), createListener(classList.get(i)));
+            listenerHashMap.put(activityNames.get(i), createListener(classList.get(i), context));
         }
         switchActivityMap = listenerHashMap;
     }
@@ -64,7 +79,7 @@ public class Taskbar {
      * @return OnClickListener with behaviour of switching to target activity.
      * @param <T> A class that extends AppCompatActivity.
      */
-    private <T extends AppCompatActivity> OnClickListener createListener(Class<T> target) {
+    private <T extends AppCompatActivity> OnClickListener createListener(Class<T> target, Context callerContext) {
         return new OnClickListener() {
             @Override
             public void onClick(View view) {


### PR DESCRIPTION
Change the taskbar to be a singleton object, so we don't have multiple copies of the taskbar running around. Change the way we create the object in Main and LeaderBoard to reflect this.