### PR TITLE
Account page display fixed

### DIFF
--- a/app/src/main/java/com/example/barqrxmls/Account.java
+++ b/app/src/main/java/com/example/barqrxmls/Account.java
@@ -59,13 +59,6 @@ public class Account extends AppCompatActivity {
 
         User user = CurrentUser.getInstance().getUser();
 
-        TextView username = findViewById(R.id.usernameField);
-        TextView email = findViewById(R.id.emailField);
-
-        username.setText(user.getUserName());
-        email.setText(user.getEmail());
-
-
         Button close = findViewById(R.id.close_button);
         close.setOnClickListener(new View.OnClickListener() {
             @Override


### PR DESCRIPTION
Fixed the account page view where the 'Username:' and 'Email:' field was being overwritten.