### PR TITLE
Remove doubled UML elements

### DIFF
--- a/app/src/main/res/layout/account_screen.xml
+++ b/app/src/main/res/layout/account_screen.xml
@@ -39,8 +39,6 @@
             android:textColor="#150578"
             android:textSize="20dp"
             android:paddingLeft="70dp"
-            android:textColor="#000"
-            android:textSize="20sp"
             android:id="@+id/usernameField"/>
 
         <TextView


### PR DESCRIPTION
Doubled UML elements in a textview caused the app to crash; this removes them.